### PR TITLE
Fixing bundle configuration.

### DIFF
--- a/src/Knp/Rad/AutoRegistration/DependencyInjection/Configuration.php
+++ b/src/Knp/Rad/AutoRegistration/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ class Configuration implements ConfigurationInterface
             ->root('knp_rad_auto_registration')
             ->children()
                 ->arrayNode('enable')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('doctrine')
                             ->defaultFalse()


### PR DESCRIPTION
When you require the package, the `enable` parameter is not defined and we currently face this error : `Notice: Undefined index: enable` (comming from the compiler pass).
